### PR TITLE
Fix: Add script to create admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ cd frontend
 npm start
 
 Enjoy!
+
+## Creating an Admin User
+
+To create an admin user, follow these steps:
+
+1.  **Create a user account** through the registration page in the application.
+2.  **Verify the user's email** by clicking the link in the verification email.
+3.  **Run the `make_admin.py` script** from the `backend` directory, passing the user's email as an argument:
+
+    ```bash
+    python scripts/make_admin.py <user_email>
+    ```
+
+    For example:
+
+    ```bash
+    python scripts/make_admin.py admin@example.com
+    ```
+
+This will grant admin privileges to the specified user.

--- a/backend/scripts/make_admin.py
+++ b/backend/scripts/make_admin.py
@@ -1,0 +1,41 @@
+import asyncio
+import os
+import sys
+from dotenv import load_dotenv
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from api.core.database import get_database
+
+async def make_admin(email: str):
+    """
+    Grants admin privileges to a user with the given email.
+    """
+    db = get_database()
+    user = await db.users.find_one({"email": email.lower()})
+
+    if not user:
+        print(f"Error: User with email '{email}' not found.")
+        return
+
+    if user.get("is_admin"):
+        print(f"User '{email}' is already an admin.")
+        return
+
+    await db.users.update_one(
+        {"_id": user["_id"]},
+        {"$set": {"is_admin": True}}
+    )
+    print(f"Successfully granted admin privileges to '{email}'.")
+
+if __name__ == "__main__":
+    # Load environment variables from .env file
+    load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
+
+    if len(sys.argv) != 2:
+        print("Usage: python backend/scripts/make_admin.py <user_email>")
+        sys.exit(1)
+
+    user_email = sys.argv[1]
+    asyncio.run(make_admin(user_email))


### PR DESCRIPTION
This commit fixes the admin login error by providing a script to grant admin privileges to a user.

The root cause of the issue was that there was no way to create an admin user through the application. The `is_admin` flag was always set to `False` on user registration.

This commit introduces a new script, `backend/scripts/make_admin.py`, which can be used to set the `is_admin` flag to `True` for a given user.

The `README.md` file has also been updated to include instructions on how to use the new script.